### PR TITLE
Add spinned variants of some MinkContext steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ The `JsonApiSteps` are helpful for testing json apis.
 
 The `WebsiteInteractionSteps` simplify DOM-based interactions with websites.
 
+### SpinnedMinkSteps
+
+The `SpinnedMinkSteps` allow calling default MinkContext steps while allowing a specified timeout.
+
 ## LICENSE
 
 The behat-utils is copyright by Exozet (http://exozet.com) and licensed under the terms of MIT License.

--- a/src/SpinnedMinkSteps.php
+++ b/src/SpinnedMinkSteps.php
@@ -26,6 +26,29 @@ trait SpinnedMinkSteps {
     }
 
     /**
+     * @see MinkContext::assertPageContainsText
+     *
+     * @Then /^sehe ich "(?P<text>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
+     * @Then /^I should see "(?P<text>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     */
+    public function assertPageContainsTextWithinSpecifiedTime($text, $seconds)
+    {
+        $seconds = (float) $seconds;
+
+        $assertPageContainsText = function($context) use ($text) {
+            try {
+                $context->assertPageContainsText($text);
+                return true;
+            }
+            catch (\Exception $e) {
+                // Do nothing, try again
+            }
+            return false;
+        };
+        $this->spin($assertPageContainsText, $seconds);
+    }
+
+    /**
      * Runs a given lambda method again and again until it returns "true".
      * If the given timeout exceeds, an Exception is thrown.
      *

--- a/src/SpinnedMinkSteps.php
+++ b/src/SpinnedMinkSteps.php
@@ -49,6 +49,103 @@ trait SpinnedMinkSteps {
     }
 
     /**
+     * @see MinkContext::assertPageNotContainsText
+     *
+     * @Then /^sehe ich "(?P<text>[^"]+)" nicht innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
+     * @Then /^I should not see "(?P<text>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     */
+    public function assertPageNotContainsTextWithinSpecifiedTime($text, $seconds)
+    {
+        $seconds = (float) $seconds;
+
+        $assertPageNotContainsText = function($context) use ($text) {
+            try {
+                $context->assertPageNotContainsText($text);
+                return true;
+            }
+            catch (\Exception $e) {
+                // Do nothing, try again
+            }
+            return false;
+        };
+        $this->spin($assertPageNotContainsText, $seconds);
+    }
+
+    /**
+     * @see MinkContext::assertElementContainsText
+     *
+     * Checks, that element with specified CSS contains specified text
+     * Example: Then I should see "Batman" in the "heroes_list" element
+     * Example: And I should see "Batman" in the "heroes_list" element
+     *
+     * @Then /^sehe ich "(?P<text>[^"]+)" im Element "(?P<element>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
+     * @Then /^I should see "(?P<text>[^"]+)" in the "(?P<element>[^"]+)" element within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     */
+    public function assertElementContainsTextWithinSpecifiedTime($element, $text, $seconds)
+    {
+        $seconds = (float) $seconds;
+
+        $assertElementContainsText = function($context) use ($element, $text) {
+            try {
+                $context->assertElementContainsText($element, $text);
+                return true;
+            }
+            catch (\Exception $e) {
+                // Do nothing, try again
+            }
+            return false;
+        };
+        $this->spin($assertElementContainsText, $seconds);
+    }
+
+    /**
+     * @see MinkContext::assertElementNotOnPage
+     *
+     * @Then /^sehe ich kein "(?P<element>[^"]+)" Element innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
+     * @Then /^I should not see an? "(?P<element>[^"]+)" element within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     */
+    public function assertElementNotOnPageWithinSpecifiedTime($element, $seconds)
+    {
+        $seconds = (float) $seconds;
+
+        $assertElementNotOnPage = function($context) use ($element) {
+            try {
+                $context->assertElementNotOnPage($element);
+                return true;
+            }
+            catch (\Exception $e) {
+                // Do nothing, try again
+            }
+            return false;
+        };
+        $this->spin($assertElementNotOnPage, $seconds);
+    }
+
+    /**
+     * @see MinkContext::fillField
+     *
+     * @When /^ich "(?P<field>[^"]+)" mit "(?P<value>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden? ausfülle$/
+     * @When /^I fill in "(?P<field>[^"]+)" with "(?P<value>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     */
+    public function fillFieldWithinSpecifiedTime($field, $value, $seconds)
+    {
+        $seconds = (float) $seconds;
+
+        $fillField = function($context) use ($field, $value) {
+            try {
+                $context->fillField($field, $value);
+                return true;
+            }
+            catch (\Exception $e) {
+                // Do nothing, try again
+            }
+            return false;
+        };
+        $this->spin($fillField, $seconds);
+    }
+
+
+    /**
      * Runs a given lambda method again and again until it returns "true".
      * If the given timeout exceeds, an Exception is thrown.
      *

--- a/src/SpinnedMinkSteps.php
+++ b/src/SpinnedMinkSteps.php
@@ -74,10 +74,6 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertElementContainsText
      *
-     * Checks, that element with specified CSS contains specified text
-     * Example: Then I should see "Batman" in the "heroes_list" element
-     * Example: And I should see "Batman" in the "heroes_list" element
-     *
      * @Then /^sehe ich "(?P<text>[^"]+)" im Element "(?P<element>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
      * @Then /^I should see "(?P<text>[^"]+)" in the "(?P<element>[^"]+)" element within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
      */

--- a/src/SpinnedMinkSteps.php
+++ b/src/SpinnedMinkSteps.php
@@ -30,8 +30,8 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertPageContainsText
      *
-     * @Then /^sehe ich "(?P<text>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
-     * @Then /^I should see "(?P<text>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     * @Then /^sehe ich "(?P<text>(?:[^"]|\\")*)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
+     * @Then /^I should see "(?P<text>(?:[^"]|\\")*)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
      *
      * @throws \Exception
      */
@@ -55,8 +55,8 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertPageNotContainsText
      *
-     * @Then /^sehe ich "(?P<text>[^"]+)" nicht innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
-     * @Then /^I should not see "(?P<text>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     * @Then /^sehe ich "(?P<text>(?:[^"]|\\")*)" nicht innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
+     * @Then /^I should not see "(?P<text>(?:[^"]|\\")*)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
      *
      * @throws \Exception
      */
@@ -80,8 +80,8 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertElementContainsText
      *
-     * @Then /^sehe ich "(?P<text>[^"]+)" im Element "(?P<element>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
-     * @Then /^I should see "(?P<text>[^"]+)" in the "(?P<element>[^"]+)" element within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     * @Then /^sehe ich "(?P<text>(?:[^"]|\\")*)" im Element "(?P<element>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
+     * @Then /^I should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]+)" element within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
      *
      * @throws \Exception
      */
@@ -130,8 +130,8 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::fillField
      *
-     * @When /^ich "(?P<field>[^"]+)" mit "(?P<value>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden? ausfülle$/
-     * @When /^I fill in "(?P<field>[^"]+)" with "(?P<value>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     * @When /^ich "(?P<field>(?:[^"]|\\")*)" mit "(?P<value>(?:[^"]|\\")*)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden? ausfülle$/
+     * @When /^I fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
      *
      * @throws \Exception
      */

--- a/src/SpinnedMinkSteps.php
+++ b/src/SpinnedMinkSteps.php
@@ -29,8 +29,8 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertPageContainsText
      *
-     * @Then /^sehe ich "#{text}" innerhalb von (?P<seconds>(\d+)) Sekunden?$/
-     * @Then /^I should see "#{text}" within (?P<seconds>(\d+)) seconds?$/
+     * @Then /^sehe ich "(?P<text>(.+))" innerhalb von (?P<seconds>(\d+)) Sekunden?$/
+     * @Then /^I should see "(?P<text>(.+))" within (?P<seconds>(\d+)) seconds?$/
      *
      * @throws \Exception
      */
@@ -52,8 +52,8 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertPageNotContainsText
      *
-     * @Then /^sehe ich "#{text}" nicht innerhalb von (?P<seconds>(\d+)) Sekunden?$/
-     * @Then /^I should not see "#{text}" within (?P<seconds>(\d+)) seconds?$/
+     * @Then /^sehe ich "(?P<text>(.+))" nicht innerhalb von (?P<seconds>(\d+)) Sekunden?$/
+     * @Then /^I should not see "(?P<text>(.+))" within (?P<seconds>(\d+)) seconds?$/
      *
      * @throws \Exception
      */
@@ -75,8 +75,8 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertElementContainsText
      *
-     * @Then /^sehe ich "#{text}" im Element "(?P<element>[^"]+)" innerhalb von (?P<seconds>(\d+)) Sekunden?$/
-     * @Then /^I should see "#{text}" in the "(?P<element>[^"]+)" element within (?P<seconds>(\d+)) seconds?$/
+     * @Then /^sehe ich "(?P<text>(.+))" im "(?P<element>[^"]+)"-Element innerhalb von (?P<seconds>(\d+)) Sekunden?$/
+     * @Then /^I should see "(?P<text>(.+))" in the "(?P<element>[^"]+)" element within (?P<seconds>(\d+)) seconds?$/
      *
      * @throws \Exception
      */
@@ -98,7 +98,7 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertElementNotOnPage
      *
-     * @Then /^sehe ich kein "(?P<element>[^"]+)" Element innerhalb von (?P<seconds>(\d+)) Sekunden?$/
+     * @Then /^sehe ich kein "(?P<element>[^"]+)"-Element innerhalb von (?P<seconds>(\d+)) Sekunden?$/
      * @Then /^I should not see an? "(?P<element>[^"]+)" element within (?P<seconds>(\d+)) seconds?$/
      *
      * @throws \Exception
@@ -121,8 +121,8 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::fillField
      *
-     * @When /^ich "#{field}" mit "#{value}" innerhalb von (?P<seconds>(\d+)) Sekunden? ausfülle$/
-     * @When /^I fill in "#{field}" with "#{value}" within (?P<seconds>(\d+)) seconds?$/
+     * @When /^ich "(?P<field>(.+))" mit "(?P<value>(.+))" innerhalb von (?P<seconds>(\d+)) Sekunden? ausfülle$/
+     * @When /^I fill in "(?P<field>(.+))" with "(?P<value>(.+))" within (?P<seconds>(\d+)) seconds?$/
      *
      * @throws \Exception
      */

--- a/src/SpinnedMinkSteps.php
+++ b/src/SpinnedMinkSteps.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Exozet\Behat\Utils\Base;
+
+trait SpinnedMinkSteps {
+    /**
+     * @see MinkContext::assertPageAddress
+     *
+     * @Then /^bin ich auf "(?P<page>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
+     * @Then /^I should be on "(?P<page>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     */
+    public function assertPageAddressWithinSpecifiedTime($page, $seconds)
+    {
+        $seconds = (float) $seconds;
+        $assertPageAddress = function($context) use ($page) {
+            try {
+                $context->assertPageAddress($page);
+                return true;
+            }
+            catch (\Exception $e) {
+                // Do nothing, try again
+            }
+            return false;
+        };
+        $this->spin($assertPageAddress, $seconds);
+    }
+
+    /**
+     * Runs a given lambda method again and again until it returns "true".
+     * If the given timeout exceeds, an Exception is thrown.
+     *
+     * @param callable $lambda The method to be executed
+     * @param int $timeout The maximum amount of seconds to be waited. Defaults to 5 seconds
+     * @throws \Exception
+     * @see https://stackoverflow.com/a/29608256
+     */
+    public function spin($lambda, $timeout = 5)
+    {
+        $time = time();
+        $stopTime = $time + $timeout;
+        while (time() < $stopTime)
+        {
+            try {
+                if ($lambda($this)) {
+                    return;
+                }
+            } catch (\Exception $e) {
+                // do nothing
+            }
+
+            usleep(250000);
+        }
+
+        throw new \Exception("Spin function timed out after {$timeout} seconds");
+    }
+}

--- a/src/SpinnedMinkSteps.php
+++ b/src/SpinnedMinkSteps.php
@@ -8,6 +8,8 @@ trait SpinnedMinkSteps {
      *
      * @Then /^bin ich auf "(?P<page>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
      * @Then /^I should be on "(?P<page>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     *
+     * @throws \Exception
      */
     public function assertPageAddressWithinSpecifiedTime($page, $seconds)
     {
@@ -30,6 +32,8 @@ trait SpinnedMinkSteps {
      *
      * @Then /^sehe ich "(?P<text>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
      * @Then /^I should see "(?P<text>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     *
+     * @throws \Exception
      */
     public function assertPageContainsTextWithinSpecifiedTime($text, $seconds)
     {
@@ -53,6 +57,8 @@ trait SpinnedMinkSteps {
      *
      * @Then /^sehe ich "(?P<text>[^"]+)" nicht innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
      * @Then /^I should not see "(?P<text>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     *
+     * @throws \Exception
      */
     public function assertPageNotContainsTextWithinSpecifiedTime($text, $seconds)
     {
@@ -76,6 +82,8 @@ trait SpinnedMinkSteps {
      *
      * @Then /^sehe ich "(?P<text>[^"]+)" im Element "(?P<element>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
      * @Then /^I should see "(?P<text>[^"]+)" in the "(?P<element>[^"]+)" element within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     *
+     * @throws \Exception
      */
     public function assertElementContainsTextWithinSpecifiedTime($element, $text, $seconds)
     {
@@ -99,6 +107,8 @@ trait SpinnedMinkSteps {
      *
      * @Then /^sehe ich kein "(?P<element>[^"]+)" Element innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
      * @Then /^I should not see an? "(?P<element>[^"]+)" element within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     *
+     * @throws \Exception
      */
     public function assertElementNotOnPageWithinSpecifiedTime($element, $seconds)
     {
@@ -122,6 +132,8 @@ trait SpinnedMinkSteps {
      *
      * @When /^ich "(?P<field>[^"]+)" mit "(?P<value>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden? ausfülle$/
      * @When /^I fill in "(?P<field>[^"]+)" with "(?P<value>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     *
+     * @throws \Exception
      */
     public function fillFieldWithinSpecifiedTime($field, $value, $seconds)
     {

--- a/src/SpinnedMinkSteps.php
+++ b/src/SpinnedMinkSteps.php
@@ -6,14 +6,13 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertPageAddress
      *
-     * @Then /^bin ich auf "(?P<page>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
-     * @Then /^I should be on "(?P<page>[^"]+)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     * @Then /^bin ich auf "(?P<page>[^"]+)" innerhalb von (?P<seconds>(\d+)) Sekunden?$/
+     * @Then /^I should be on "(?P<page>[^"]+)" within (?P<seconds>(\d+)) seconds?$/
      *
      * @throws \Exception
      */
     public function assertPageAddressWithinSpecifiedTime($page, $seconds)
     {
-        $seconds = (float) $seconds;
         $assertPageAddress = function($context) use ($page) {
             try {
                 $context->assertPageAddress($page);
@@ -30,15 +29,13 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertPageContainsText
      *
-     * @Then /^sehe ich "(?P<text>(?:[^"]|\\")*)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
-     * @Then /^I should see "(?P<text>(?:[^"]|\\")*)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     * @Then /^sehe ich "#{text}" innerhalb von (?P<seconds>(\d+)) Sekunden?$/
+     * @Then /^I should see "#{text}" within (?P<seconds>(\d+)) seconds?$/
      *
      * @throws \Exception
      */
     public function assertPageContainsTextWithinSpecifiedTime($text, $seconds)
     {
-        $seconds = (float) $seconds;
-
         $assertPageContainsText = function($context) use ($text) {
             try {
                 $context->assertPageContainsText($text);
@@ -55,15 +52,13 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertPageNotContainsText
      *
-     * @Then /^sehe ich "(?P<text>(?:[^"]|\\")*)" nicht innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
-     * @Then /^I should not see "(?P<text>(?:[^"]|\\")*)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     * @Then /^sehe ich "#{text}" nicht innerhalb von (?P<seconds>(\d+)) Sekunden?$/
+     * @Then /^I should not see "#{text}" within (?P<seconds>(\d+)) seconds?$/
      *
      * @throws \Exception
      */
     public function assertPageNotContainsTextWithinSpecifiedTime($text, $seconds)
     {
-        $seconds = (float) $seconds;
-
         $assertPageNotContainsText = function($context) use ($text) {
             try {
                 $context->assertPageNotContainsText($text);
@@ -80,15 +75,13 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertElementContainsText
      *
-     * @Then /^sehe ich "(?P<text>(?:[^"]|\\")*)" im Element "(?P<element>[^"]+)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
-     * @Then /^I should see "(?P<text>(?:[^"]|\\")*)" in the "(?P<element>[^"]+)" element within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     * @Then /^sehe ich "#{text}" im Element "(?P<element>[^"]+)" innerhalb von (?P<seconds>(\d+)) Sekunden?$/
+     * @Then /^I should see "#{text}" in the "(?P<element>[^"]+)" element within (?P<seconds>(\d+)) seconds?$/
      *
      * @throws \Exception
      */
     public function assertElementContainsTextWithinSpecifiedTime($element, $text, $seconds)
     {
-        $seconds = (float) $seconds;
-
         $assertElementContainsText = function($context) use ($element, $text) {
             try {
                 $context->assertElementContainsText($element, $text);
@@ -105,15 +98,13 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::assertElementNotOnPage
      *
-     * @Then /^sehe ich kein "(?P<element>[^"]+)" Element innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden?$/
-     * @Then /^I should not see an? "(?P<element>[^"]+)" element within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     * @Then /^sehe ich kein "(?P<element>[^"]+)" Element innerhalb von (?P<seconds>(\d+)) Sekunden?$/
+     * @Then /^I should not see an? "(?P<element>[^"]+)" element within (?P<seconds>(\d+)) seconds?$/
      *
      * @throws \Exception
      */
     public function assertElementNotOnPageWithinSpecifiedTime($element, $seconds)
     {
-        $seconds = (float) $seconds;
-
         $assertElementNotOnPage = function($context) use ($element) {
             try {
                 $context->assertElementNotOnPage($element);
@@ -130,15 +121,13 @@ trait SpinnedMinkSteps {
     /**
      * @see MinkContext::fillField
      *
-     * @When /^ich "(?P<field>(?:[^"]|\\")*)" mit "(?P<value>(?:[^"]|\\")*)" innerhalb von (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) Sekunden? ausfülle$/
-     * @When /^I fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)" within (?P<seconds>[0-9]+([.][0-9]*)?|[.][0-9]+) seconds?$/
+     * @When /^ich "#{field}" mit "#{value}" innerhalb von (?P<seconds>(\d+)) Sekunden? ausfülle$/
+     * @When /^I fill in "#{field}" with "#{value}" within (?P<seconds>(\d+)) seconds?$/
      *
      * @throws \Exception
      */
     public function fillFieldWithinSpecifiedTime($field, $value, $seconds)
     {
-        $seconds = (float) $seconds;
-
         $fillField = function($context) use ($field, $value) {
             try {
                 $context->fillField($field, $value);


### PR DESCRIPTION
This PR adds ["spinned" variants](http://docs.behat.org/en/v2.5/cookbook/using_spin_functions.html) of the following MinkContext steps:
- `MinkContext::assertPageAddress`
- `MinkContext::assertPageContainsText`
- `MinkContext::assertPageNotContainsText`
- `MinkContext::assertElementContainsText`
- `MinkContext::assertElementNotOnPage`
- `MinkContext::fillField`

Those spinned steps can be used to allow some time until an assertion has to be fulfilled—_without having to wait synchronously for a hard-coded amount of time_. The `spin` method implemented in this PR is based on https://stackoverflow.com/questions/28510155/how-to-get-the-mink-selenium-2-driver-to-wait-for-the-page-to-load-with-behat.