### PR TITLE
Allow checking elements' visibility in viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0] - 2018-08-30
+### Added
+- Add TravisCI support for behat-utils
+- Add "SpinnedMinkSteps" trait for calling default MinkContext steps with a specified timeout
+
+## [0.3.0] - 2018-08-10
+### Added
+- Add "WebsiteInteractionSteps" trait for interacting with websites based on DOM elements
+### Changed
+- Remove unnecessary duplicate "require" from composer.json
+
+## [0.2.0] - 2017-12-12
+### Changed
+- Fix typos in JsonApiSteps
+- Pass HTTP headers to POST requests in JsonApiSteps
+
+## [0.1.0] - 2017-03-27
+### Added
+- Add "JsonApiSteps" trait for sending, receiving and asserting JSON data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add "waitForVisibleMatchingElementsWithinSpecifiedTime" step that allows checking elements' visibility in viewport
 
 ## [0.4.0] - 2018-08-30
 ### Added


### PR DESCRIPTION
This PR adds a step that allows checking whether elements matching a given selector `$seelctor` are both _visible_ (i. e. not hidden) and _in the viewport_ within a given time interval `$seconds`. The step succeeds in either way—if the element(s) are visible and in the viewport, **or** if the given time interval has passed. 

The step can be used to “delay” the test execution until elements matching the given selector are actually visible and in the viewport. This is especially useful when the subsequent scenario steps rely on e. g. a button element being actually visually clickable and not only being technically present in the DOM.